### PR TITLE
Changed CGImageCreate arguments to take into account color conversions

### DIFF
--- a/OpenCV Tutorial/UIImage2OpenCV.mm
+++ b/OpenCV Tutorial/UIImage2OpenCV.mm
@@ -103,11 +103,11 @@
   CGBitmapInfo bmInfo = kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big;
   
   // Creating CGImage from cv::Mat
-  CGImageRef imageRef = CGImageCreate(image.cols,                                 //width
-                                      image.rows,                                 //height
+  CGImageRef imageRef = CGImageCreate(rgbaView.cols,                              //width
+                                      rgbaView.rows,                              //height
                                       8,                                          //bits per component
-                                      8 * image.elemSize(),                       //bits per pixel
-                                      image.step.p[0],                            //bytesPerRow
+                                      8 * rgbaView.elemSize(),                    //bits per pixel
+                                      rgbaView.step.p[0],                         //bytesPerRow
                                       colorSpace,                                 //colorspace
                                       bmInfo,// bitmap info
                                       provider,                                   //CGDataProviderRef


### PR DESCRIPTION
Creating an image from a gray Mat resulted to the error: `CGImageCreate: invalid image bits/pixel: 8`.
So, I might be wrong, but I think this was a mistake.