### PR TITLE
explicit (int) casts

### DIFF
--- a/OpenCV Tutorial/UIImage2OpenCV.mm
+++ b/OpenCV Tutorial/UIImage2OpenCV.mm
@@ -14,8 +14,8 @@
 {
   CGImageRef imageRef = self.CGImage;
   
-  const int srcWidth        = CGImageGetWidth(imageRef);
-  const int srcHeight       = CGImageGetHeight(imageRef);
+  const int srcWidth        = (int)CGImageGetWidth(imageRef);
+  const int srcHeight       = (int)CGImageGetHeight(imageRef);
   //const int stride          = CGImageGetBytesPerRow(imageRef);
   //const int bitPerPixel     = CGImageGetBitsPerPixel(imageRef);
   //const int bitPerComponent = CGImageGetBitsPerComponent(imageRef);


### PR DESCRIPTION
added explicit int casts to prevent warnings when compiling for 64 bit.
